### PR TITLE
Fix `warning: constant ::Data is deprecated` from Ruby 2.5

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -1272,7 +1272,7 @@ iconv_failure_inspect(VALUE self)
 void
 Init_iconv(void)
 {
-    VALUE rb_cIconv = rb_define_class("Iconv", rb_cData);
+    VALUE rb_cIconv = rb_define_class("Iconv", rb_cObject);
 
     rb_define_alloc_func(rb_cIconv, iconv_s_allocate);
     rb_define_singleton_method(rb_cIconv, "open", iconv_s_open, -1);

--- a/lib/iconv.rb
+++ b/lib/iconv.rb
@@ -1,6 +1,6 @@
 require "iconv/iconv.so"
 require "iconv/version"
 
-class Iconv < Data
+class Iconv
   # Your code goes here...
 end

--- a/lib/iconv/version.rb
+++ b/lib/iconv/version.rb
@@ -1,3 +1,3 @@
-class Iconv < Data
+class Iconv
   VERSION = "1.0.4"
 end


### PR DESCRIPTION
This commit fixes the following warning.

```console
% ruby -riconv -ve "Iconv.conv('iso-8859-15', 'utf-8', 'hello')"
ruby 2.5.0dev (2017-12-07 trunk 61059) [x86_64-darwin13]
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/iconv-1.0.4/lib/iconv/version.rb:1: warning: constant ::Data is deprecated
/Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/iconv-1.0.4/lib/iconv.rb:4: warning: constant ::Data is deprecated
```

Related issue ... https://bugs.ruby-lang.org/issues/3072