### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, head ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, head, truffleruby-head ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
TruffleRuby recently merged [fixes](https://github.com/oracle/truffleruby/commit/370fbff09ddae2aec98dceb45633dc6c68de7d53) to support the `iconv` gem, so it'd be great to add TruffleRuby in CI.