### PR TITLE
Fix exclusion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
         exclude:
           - os: macos-15-intel
-          - ruby: truffleruby
+            ruby: truffleruby
           - ruby: 2.3
             os: macos-latest
           - ruby: 2.4


### PR DESCRIPTION
* This excluded all `macos-15-intel` jobs and all `truffleruby` jobs.

See 3d44eb53f4350ba920bfb6ed57b894f2a4627e51